### PR TITLE
add: LINE Botの基本機能を追加する

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-pass
+line-bot-sdk==3.7.0
+fastapi==0.108.0
+python-dotenv==1.0.0
+uvicorn==0.25.0

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,48 @@
+import os
+
+from dotenv import load_dotenv
+from fastapi import HTTPException
+from fastapi import FastAPI, Request
+from linebot import LineBotApi
+from linebot.v3.webhook import WebhookHandler
+from linebot.exceptions import InvalidSignatureError
+from linebot.models import MessageEvent, TextSendMessage
+
+load_dotenv(verbose=True)
+
+app = FastAPI()
+line_bot_api = LineBotApi(os.environ["LINE_CHANNEL_ACCESS_TOKEN"])
+handler = WebhookHandler(os.environ.get("LINE_CHANNEL_SECRET"))
+
+
+@app.get("/")
+def root():
+    return {"message": "Welcome to LINE Bot"}
+
+
+@app.post("/callback")
+async def callback(
+    request: Request,
+) -> str:
+    signature = request.headers["X-Line-Signature"]
+    body = await request.body()
+    try:
+        handler.handle(body.decode("utf-8"), signature)
+    except InvalidSignatureError:
+        raise HTTPException(status_code=400, detail="Invalid Signature Error.")
+    return "OK"
+
+
+@handler.add(MessageEvent)
+def handle_message(event: MessageEvent) -> None:
+    """
+    LINE Messaging APIのハンドラより呼び出される処理です。
+    受け取ったメッセージに従い返信メッセージを返却します。
+
+    Parameters
+    ----------
+    event : MessageEvent
+        送信されたメッセージの情報です。
+    """
+    message = event.message.text
+    line_bot_api.reply_message(event.reply_token, TextSendMessage(text=message))


### PR DESCRIPTION
# 目的・概要
LINE-Bot✖️RAGのサービス開発をしたい
- LINE Botの基本機能を開発する
  - メッセージを送って、そのまま返信する
- 今後、RAGによる返信機能を追加する

# チケット・参考リンク
- なし

# 変更内容
- ライブラリの追加
- LINE Botの基本メソッドを追加する

# 動作確認（確認方法とプロセスを明確に記載する）
- ローカルによる確認
  - ngrokを使って、httpsのURLを作成
    - `ngrok http 8000`
    - webhoolに /callbackのリンクを追加する
  - fastapiの起動
    - `uvicorn src.main:app --reload --host=127.0.0.1`
  - 公式LINE Botにメッセージを送信する

# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか